### PR TITLE
Add support to manage TSIG keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,23 @@ The title of `resource_record` resources can be in one of the following formats:
 1. Name: `www` (record `www` with zone and type specified as parameters)
 1. Any other format means all of the required parameters need to be specified in the resource definition.
 
+### The `bind::key` defined type
+
+TSIG keys for dynamic zone updates used by clients can be added to the configuration as follows.
+
+```puppet
+bind::key { 'key_name':
+  algorithm => 'hmac-sha512',
+  secret    => 'ZlfCDgP7d3g7LjV4YMLg62EbpLZRCt9BMh3MyqiZfPX5Y2IcTyx/la6PMsfAqLMM9QDadZiNiLVzD4IPoI/4hg==',
+}
+```
+
+The key's secret needs to be generated using the BIND tool `tsig-keygen`; example:
+
+```bash
+tsig-keygen -a $algorithm [$key_name]
+```
+
 ## Limitations
 
 See [`metadata.json`](metadata.json) for supported operating systems, supported Puppet versions,

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -18,6 +18,7 @@
 
 ### Defined types
 
+* [`bind::key`](#bindkey)
 * [`bind::zone`](#bindzone): A DNS zone
 
 ### Resource types
@@ -101,6 +102,7 @@ The following parameters are available in the `bind` class:
 * [`zone_default_rname`](#zone_default_rname)
 * [`zone_default_serial`](#zone_default_serial)
 * [`zone_default_ttl`](#zone_default_ttl)
+* [`keys`](#keys)
 
 ##### <a name="authoritative"></a>`authoritative`
 
@@ -432,7 +434,38 @@ in the `$zones` parameter. Also, individual resource records can override this v
 
 Default value: `'2d'`
 
+##### <a name="keys"></a>`keys`
+
+Data type: `Hash`
+
+Hash for creating Bind::Key resources.
+
+Default value: `{}`
+
 ## Defined types
+
+### <a name="bindkey"></a>`bind::key`
+
+The bind::key class.
+
+#### Parameters
+
+The following parameters are available in the `bind::key` defined type:
+
+* [`algorithm`](#algorithm)
+* [`secret`](#secret)
+
+##### <a name="algorithm"></a>`algorithm`
+
+Data type: `Enum['hmac-sha256', 'hmac-sha384', 'hmac-sha512']`
+
+
+
+##### <a name="secret"></a>`secret`
+
+Data type: `String[44]`
+
+
 
 ### <a name="bindzone"></a>`bind::zone`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -86,4 +86,10 @@ class bind::config {
       * => $zone,
     }
   }
+
+  $bind::keys.each |$k, $v| {
+    bind::key { $k:
+      * => $v,
+    }
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -148,6 +148,9 @@
 #   in the `$zones` parameter. Also, individual resource records can override this value with the
 #   `ttl` key in their hashes. Reference: [RFC 2308](https://tools.ietf.org/html/rfc2308#section-4)
 #
+# @param keys
+#   Hash for creating Bind::Key resources.
+#
 class bind (
   Boolean $authoritative = false,
   Stdlib::Absolutepath $config_dir = '/etc/bind',
@@ -188,6 +191,7 @@ class bind (
   String[1] $zone_default_rname = 'hostmaster',
   Integer[0] $zone_default_serial = 1,
   String[1] $zone_default_ttl = '2d',
+  Hash $keys = {},
 ) {
   contain bind::install
   contain bind::config

--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# @summary Create TSIG key for zone updates in the configuration file for BIND domain name server.
+#   Technical details: https://bind9.readthedocs.io/en/latest/advanced.html#tsig
+#
+# @example Add a TSIG key to the nameserver
+#   bind::key { 'tsig-client':
+#     algorithm => 'hmac-sha512',
+#     secret    => 'secret-key-data',
+#   }
+#
+# @param algorithm
+#   Defines the algorithm which was used to generate the key data.
+#   For security reasons just allow algorithms hmac-sha256 and above:
+#   https://www.rfc-editor.org/rfc/rfc8945.html#name-algorithms-and-identifiers
+#
+# @param secret
+#   Provide the secret data of the TSIG key, generated using tsig-keygen.
+
+define bind::key (
+  Enum['hmac-sha256', 'hmac-sha384', 'hmac-sha512'] $algorithm,
+  String[44] $secret,
+) {
+  include bind
+
+  concat::fragment { "key-${name}":
+    target  => $bind::service_config_file,
+    content => epp("${module_name}/key.epp", {
+      name      => $name,
+      algorithm => $algorithm,
+      secret    => $secret,
+    }),
+  }
+}

--- a/spec/classes/bind_spec.rb
+++ b/spec/classes/bind_spec.rb
@@ -1050,6 +1050,28 @@ describe 'bind' do
           )
         end
       end
+
+      context 'with custom keys' do
+        let(:params) do
+          {
+            keys: {
+              'key1': {
+                algorithm: 'hmac-sha256',
+                secret: 'yHqINVuege3zW3EOebA8pnWzpMkpCpMi0f4RqrV4poU=',
+              },
+              'key2': {
+                algorithm: 'hmac-sha512',
+                secret: '+2BboRCD6wsbAmqXs2lcg7RzkG3gCN6CgP0oI7FRudJh70JSFmyytOUld+jezwH7tyYgv3B89y18A2AMev+HQQ==',
+              },
+            },
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+
+        it { is_expected.to contain_bind__key('key1') }
+        it { is_expected.to contain_bind__key('key2') }
+      end
     end
   end
 end

--- a/spec/defines/tsig_key_spec.rb
+++ b/spec/defines/tsig_key_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+require 'spec_helper'
+
+describe 'bind::key' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'generate tsig key' do
+        let(:title) { 'sample' }
+        let(:params) do
+          {
+            algorithm: 'hmac-sha512',
+            secret: 'ZlfCDgP7d3g7LjV4YMLg62EbpLZRCt9BMh3MyqiZfPX5Y2IcTyx/la6PMsfAqLMM9QDadZiNiLVzD4IPoI/4hg==',
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+
+        it do
+          is_expected.to contain_concat__fragment("key-#{title}").with(
+            target: CONFIG_FILE,
+            content: <<~CONTENT,
+              key "#{title}" {
+                  algorithm #{params[:algorithm]};
+                  secret "#{params[:secret]}";
+              };
+            CONTENT
+          )
+        end
+      end
+    end
+  end
+end

--- a/templates/key.epp
+++ b/templates/key.epp
@@ -1,0 +1,8 @@
+<%- | String[1] $name,
+      String[11] $algorithm,
+      String[44] $secret,
+ | -%>
+key "<%= $name %>" {
+    algorithm <%= $algorithm %>;
+    secret "<%= $secret %>";
+};


### PR DESCRIPTION
As a system administrator I would like to add custom TSIG keys to BIND so dynamic zone updates or transfers can be restricted using key-based ACLs: https://bind9.readthedocs.io/en/latest/advanced.html#tsig-based-access-control