### PR TITLE
Series of changes:

### DIFF
--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -62,9 +62,9 @@
 #
 define bind::zone (
   Pattern[/\.$/] $zone_name = $title,
-  Optional[Array[Variant[Stdlib::Host, Stdlib::IP::Address]]] $allow_transfer = undef,
-  Optional[Array[Variant[Stdlib::Host, Stdlib::IP::Address]]] $allow_update = undef,
-  Optional[Array[Variant[Stdlib::Host, Stdlib::IP::Address]]] $also_notify = undef,
+  Optional[Array[Variant[Stdlib::Host, Stdlib::IP::Address, Stdlib::Compat::String]]] $allow_transfer = undef,
+  Optional[Array[Variant[Stdlib::Host, Stdlib::IP::Address, Stdlib::Compat::String]]] $allow_update = undef,
+  Optional[Array[Variant[Stdlib::Host, Stdlib::IP::Address, Stdlib::Compat::String]]] $also_notify = undef,
   Optional[Enum['allow', 'maintain', 'off']] $auto_dnssec = undef,
   Optional[Enum['IN', 'HS', 'hesiod', 'CHAOS']] $class = undef,
   Optional[String[1]] $file = undef,

--- a/templates/etc/bind/named.conf.epp
+++ b/templates/etc/bind/named.conf.epp
@@ -39,6 +39,8 @@ logging {
         print-time <%= $channel_config['print-time'] %>;
           <%- } if $channel_config['severity'] { -%>
         severity <%= $channel_config['severity'] %>;
+          <%- } if $channel_config['syslog'] { -%>
+        syslog <%= $channel_config['syslog'] %>;
           <%- } -%>
         <%- } -%>
       <%- } -%>

--- a/types/options.pp
+++ b/types/options.pp
@@ -5,14 +5,21 @@
 # Reference: https://bind9.readthedocs.io/en/latest/reference.html#options-statement-grammar
 #
 type Bind::Options = Struct[{
-  Optional['allow-transfer'] => Array[Variant[Stdlib::Host, Stdlib::IP::Address]],
-  Optional['allow-update'] => Array[Variant[Stdlib::Host, Stdlib::IP::Address]],
+  Optional['allow-transfer'] => Array[Variant[Stdlib::Host, Stdlib::IP::Address, Stdlib::Compat::String]],
+  Optional['allow-update'] => Array[Variant[Stdlib::Host, Stdlib::IP::Address, Stdlib::Compat::String]],
   Optional['allow-query'] => Array[Variant[Stdlib::Host, Stdlib::IP::Address]],
-  Optional['also-notify'] => Array[Variant[Stdlib::Host, Stdlib::IP::Address]],
+  Optional['also-notify'] => Array[Variant[Stdlib::Host, Stdlib::IP::Address, Stdlib::Compat::String]],
   Optional['auto-dnssec'] => Enum['allow', 'maintain', 'off'],
   Optional['directory'] => Stdlib::Absolutepath,
+  Optional['dnssec-enable'] => Variant[Boolean, Stdlib::Yes_no],
+  Optional['dnssec-validation'] => Stdlib::Compat::String,
   Optional['inline-signing'] => Variant[Boolean, Stdlib::Yes_no],
   Optional['key-directory'] => String[1],
+  Optional['listen-on'] => Array[Variant[Stdlib::Host, Stdlib::IP::Address, Stdlib::Compat::String]],
+  Optional['listen-on-v6'] => Array[Variant[Stdlib::Host, Stdlib::IP::Address, Stdlib::Compat::String]],
+  Optional['recursion'] => Variant[Boolean, Stdlib::Yes_no],
   Optional['serial-update-method'] => Enum['date', 'increment', 'unixtime'],
+  Optional['tkey-gssapi-keytab'] => Stdlib::Absolutepath,
+  Optional['version'] => Stdlib::Compat::String,
   Optional['zone-statistics'] => Variant[Boolean, Stdlib::Yes_no, Enum['full', 'terse', 'none']],
 }]


### PR DESCRIPTION
- Add additional Bind::Options: dnssec-enable, dnssec-validation, listen-on, listen-on-v6, recursion, tkey-gssapi-keytab, version
- Enable support for TSIG authentication for: allow-transfer, allow-update, also_notify
- Fix an issue with Bind::Logging when using syslog channel logging