### PR TITLE
install: remove workaround for mkdir command not found

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -19,16 +19,6 @@ class bind::install {
       },
     )
 
-    # workaround for https://github.com/rvm/rvm/issues/4975
-    # The dnsruby build fails with the Ruby 2.7.1 build included with Puppet 7.1.0 if /usr/bin/mkdir
-    # is missing.
-    # FIXME: remove this when Puppet's Ruby is fixed.
-    file { '/usr/bin/mkdir':
-      ensure => link,
-      target => '/bin/mkdir',
-      before => Package['dnsruby'],
-    }
-
     ensure_packages(
       'dnsruby',
       {

--- a/spec/classes/bind_spec.rb
+++ b/spec/classes/bind_spec.rb
@@ -233,15 +233,6 @@ describe 'bind' do
           end
         end
 
-        # workaround for https://github.com/rvm/rvm/issues/4975
-        it do
-          is_expected.to contain_file('/usr/bin/mkdir').with(
-            ensure: 'link',
-            target: '/bin/mkdir',
-            before: 'Package[dnsruby]',
-          )
-        end
-
         it do
           is_expected.to contain_package('dnsruby').with(
             ensure: 'installed',


### PR DESCRIPTION
Not needed with current Puppet (7.9.0 in PDK).

Closes #10