### PR TITLE
Full CRUD for resource records

### DIFF
--- a/lib/puppet/provider/resource_record/resource_record.rb
+++ b/lib/puppet/provider/resource_record/resource_record.rb
@@ -1,40 +1,140 @@
 # frozen_string_literal: true
 
 require 'puppet/resource_api/simple_provider'
-
+require 'ipaddr'
 # Implementation for the resource_record type using the Resource API.
 class Puppet::Provider::ResourceRecord::ResourceRecord < Puppet::ResourceApi::SimpleProvider
+  def initialize
+    system('rndc', 'dumpdb', '-zones')
+  end
   def get(context)
-    context.debug('Returning pre-canned example data')
-    [
-      {
-        name: 'foo',
-        ensure: 'present',
-      },
-      {
-        name: 'bar',
-        ensure: 'present',
-      },
-    ]
+    context.debug("Parsing dump for existing resource records...")
+
+    records = []
+    currentzone = ""
+    #FIXME: location varies based on config/OS
+    File.readlines('/var/cache/bind/named_dump.db').each do |line|
+      if line[0] == ';' && line.length > 18
+        currentzone = line[/(?:.*?')(.*?)\//,1]
+        context.debug("current zone updated: #{currentzone}")
+      elsif line[0] != ';'
+        line = line.strip.split(' ', 5)
+        rr = {}
+        rr[:label] = line[0]
+        context.debug("----New RR---- label: #{rr[:label]}")
+        rr[:ttl] = line[1]
+        context.debug("RR TTL: #{rr[:ttl]}")
+        rr[:scope] = line[2]
+        context.debug("RR scope: #{rr[:scope]}")
+        rr[:type] = line[3]
+        context.debug("RR type: #{rr[:type]}")
+        if line[4].respond_to?(:to_str)
+          rr[:data] = line[4].tr('\"', '')
+        else
+          rr[:data] = line[4]
+        end
+        context.debug("RR data: #{rr[:data]}")
+        rr[:zone] = currentzone + '.'
+        context.debug("RR zone: #{rr[:zone]}")
+        records << {
+          title: "#{rr[:label]} #{rr[:zone]} #{rr[:type]}",
+          ensure: 'present',
+          record: "#{rr[:label]}",
+          zone:   "#{rr[:zone]}",
+          type:   "#{rr[:type]}",
+          data:   "#{rr[:data]}",
+          ttl:    "#{rr[:ttl]}",
+        }
+      end
+    end
+    context.debug("#{records.inspect}")
+    records
   end
 
   def create(context, name, should)
     context.notice("Creating '#{name}' with #{should.inspect}")
+
+    #I dislike having to send an individual nsupdate for each record, it'd be preferable to
+    #build a request for each managed zone on run, append all records we
+    #need to act on, then send a bulk nsupdate for each zone
+
+    #the delete line is temporary to prevent duplicate creations while this is in progress
+    cmd = "echo 'zone #{should[:zone]}
+    update delete #{should[:record]} #{should[:type]}
+    update add #{should[:record]} #{should[:ttl]} #{should[:type]} #{should[:data]}
+    send
+    quit
+    ' | nsupdate -4 -l"
+    system(cmd)
+
+    #FIXME: This will generate PTR records, but assumes the arpa zones are preexisting.
+    if should[:type] == "A"
+      fqdn = should[:record]
+      if fqdn[fqdn.length-1] != "."
+        fqdn = fqdn + should[:zone]
+      end
+      reverse = IPAddr.new(should[:data]).reverse
+      cmd = "echo 'update delete #{reverse} PTR
+      update add #{reverse} #{should[:ttl]} PTR #{fqdn}
+      send
+      quit
+      ' | nsupdate -4 -l"
+      system(cmd)
+    end
   end
 
   def update(context, name, should)
-    context.notice("Updating '#{name}' with #{should.inspect}")
-  end
+    context.notice("Updating '#{name.inspect}' with #{should.inspect}")
+    cmd = "echo 'zone #{should[:zone]}
+    update delete #{name[:record]} #{name[:type]}
+    update add #{should[:record]} #{should[:ttl]} #{should[:type]} #{should[:data]}
+    send
+    quit
+    ' | nsupdate -4 -l"
+    system(cmd)
+    if should[:type] == "A"
+      fqdn = should[:record]
+      if fqdn[fqdn.length-1] != "."
+        fqdn = fqdn + should[:zone]
+      end
+      reverse = IPAddr.new(should[:data]).reverse
+      context.debug("fqdn: #{fqdn}")
+      context.debug("reverse: #{reverse}")
+      cmd = "echo 'update delete #{reverse} PTR
+      update add #{reverse} #{should[:ttl]} PTR #{fqdn}
+      send
+      quit
+      ' | nsupdate -4 -l"
+      system(cmd)
+    end
+   end
 
   def delete(context, name)
     context.notice("Deleting '#{name}'")
+    cmd = "echo 'zone #{name[:zone]}
+    update delete #{name[:record]} #{name[:type]}
+    send
+    quit
+    ' | nsupdate -4 -l"
+    system(cmd)
   end
 
   def canonicalize(_context, resources)
     resources.each do |r|
-      r[:record] = r[:record].downcase
-      r[:zone] = r[:zone].downcase
-      r[:type] = r[:type].upcase
+
+      _context.debug("#{r.inspect}")
+      if r[:record].respond_to?(:to_str)
+        r[:record] = r[:record].downcase.strip
+      end
+      if r[:zone].respond_to?(:to_str)
+        r[:zone] = r[:zone].downcase
+      end
+      if r[:type].respond_to?(:to_str)
+        r[:type] = r[:type].upcase
+      end
+      if r[:data].respond_to?(:to_str)
+        r[:data] = r[:data].tr('\"', '')
+      end
     end
   end
 end

--- a/lib/puppet/type/resource_record.rb
+++ b/lib/puppet/type/resource_record.rb
@@ -21,8 +21,8 @@ Puppet::ResourceApi.register_type(
   features: ['canonicalize'],
   title_patterns: [
     {
-      desc: 'name, zone (everything after the first dot), space, type',
-      pattern: %r{^(?<record>.*?[^.])\.(?<zone>.*[^ ]\.) +(?<type>.*)$},
+      desc: 'full name, space, zone (explicitly defined), space, type',
+      pattern: %r{^(?<record>.*?\.) (?<zone>.*[^ ]\.) +(?<type>.*)$},
     },
     {
       desc: 'name and zone (everything after the first dot)',


### PR DESCRIPTION
Based off of current main, I've added resource record management to the simple provider that was in place. 

Admittedly, I don't have the appropriate development environment configured (i.e. linting) or tests created and it's not pretty so I don't expect this to make it into main any time soon, but this will hopefully get you a lot closer to having this feature ready should you be interested in working on it in the future. Thus far it seems to be fully functional CRUD, so I'll be using the fork in production in the meantime. 